### PR TITLE
Library's DTOs wrapper with internal DTOs

### DIFF
--- a/src/main/java/com/github/shaart/team/f/discord/bot/command/BotCommand.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/command/BotCommand.java
@@ -1,6 +1,6 @@
 package com.github.shaart.team.f.discord.bot.command;
 
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
 
 /**
  * A command to be processed by bot.
@@ -39,5 +39,5 @@ public interface BotCommand {
    * @param event a message event
    * @param args  parsed command's arguments if present (or empty array if none)
    */
-  void run(MessageReceivedEvent event, String... args);
+  void run(EventDto event, String... args);
 }

--- a/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/HelpCommand.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/HelpCommand.java
@@ -6,13 +6,13 @@ import static com.github.shaart.team.f.discord.bot.service.CommandService.DEFAUL
 import com.github.shaart.team.f.discord.bot.command.AbstractBotCommand;
 import com.github.shaart.team.f.discord.bot.command.BotCommand;
 import com.github.shaart.team.f.discord.bot.component.MessageSender;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import com.github.shaart.team.f.discord.bot.dto.CommandDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
 import com.github.shaart.team.f.discord.bot.properties.TeamFDiscordBotProperties;
 import com.github.shaart.team.f.discord.bot.service.CommandService;
 import com.github.shaart.team.f.discord.bot.util.BotNumberUtils;
 import lombok.Setter;
-import net.dv8tion.jda.api.entities.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -73,8 +73,8 @@ public class HelpCommand extends AbstractBotCommand {
   }
 
   @Override
-  public void run(MessageReceivedEvent event, String... args) {
-    final MessageChannel channel = event.getChannel();
+  public void run(EventDto event, String... args) {
+    final ChannelDto channel = event.getChannel();
 
     List<BotCommand> commandsPage = getBotCommands(args);
 

--- a/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/PingCommand.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/PingCommand.java
@@ -2,9 +2,9 @@ package com.github.shaart.team.f.discord.bot.command.impl;
 
 import com.github.shaart.team.f.discord.bot.command.AbstractBotCommand;
 import com.github.shaart.team.f.discord.bot.component.MessageSender;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
 import com.github.shaart.team.f.discord.bot.properties.TeamFDiscordBotProperties;
-import net.dv8tion.jda.api.entities.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -42,8 +42,8 @@ public class PingCommand extends AbstractBotCommand {
   }
 
   @Override
-  public void run(MessageReceivedEvent event, String... args) {
-    final MessageChannel channel = event.getChannel();
+  public void run(EventDto event, String... args) {
+    final ChannelDto channel = event.getChannel();
     messageSender.sendMessage(channel, "Pong!");
   }
 }

--- a/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/RandomCommand.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/command/impl/RandomCommand.java
@@ -2,9 +2,9 @@ package com.github.shaart.team.f.discord.bot.command.impl;
 
 import com.github.shaart.team.f.discord.bot.command.AbstractBotCommand;
 import com.github.shaart.team.f.discord.bot.component.MessageSender;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
 import com.github.shaart.team.f.discord.bot.properties.TeamFDiscordBotProperties;
-import net.dv8tion.jda.api.entities.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -46,8 +46,8 @@ public class RandomCommand extends AbstractBotCommand {
   }
 
   @Override
-  public void run(MessageReceivedEvent event, String... args) {
-    final MessageChannel channel = event.getChannel();
+  public void run(EventDto event, String... args) {
+    final ChannelDto channel = event.getChannel();
 
     final int mix = Integer.parseInt(args[0]);
     final int max = Integer.parseInt(args[1]);

--- a/src/main/java/com/github/shaart/team/f/discord/bot/component/MessageSender.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/component/MessageSender.java
@@ -1,6 +1,6 @@
 package com.github.shaart.team.f.discord.bot.component;
 
-import net.dv8tion.jda.api.entities.MessageChannel;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 
 /**
  * Message sender for messages publishing in discord channel.
@@ -13,7 +13,7 @@ public interface MessageSender {
    * @param channel destination channel
    * @param message message to post
    */
-  void sendMessage(MessageChannel channel, String message);
+  void sendMessage(ChannelDto channel, String message);
 
   /**
    * Send an <b>error</b> message to channel.
@@ -21,5 +21,5 @@ public interface MessageSender {
    * @param channel destination channel
    * @param message message to post
    */
-  void sendError(MessageChannel channel, String message);
+  void sendError(ChannelDto channel, String message);
 }

--- a/src/main/java/com/github/shaart/team/f/discord/bot/component/impl/MessageSenderImpl.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/component/impl/MessageSenderImpl.java
@@ -3,8 +3,8 @@ package com.github.shaart.team.f.discord.bot.component.impl;
 import static java.util.Objects.isNull;
 
 import com.github.shaart.team.f.discord.bot.component.MessageSender;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.entities.MessageChannel;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -17,7 +17,7 @@ public class MessageSenderImpl implements MessageSender {
   private static final String OVERFLOW_POSTFIX = "..";
 
   @Override
-  public void sendMessage(MessageChannel channel, String message) {
+  public void sendMessage(ChannelDto channel, String message) {
     if (isNull(message)) {
       sendError(channel, NO_MESSAGE_PRODUCED_ERROR);
       return;
@@ -26,11 +26,11 @@ public class MessageSenderImpl implements MessageSender {
   }
 
   @Override
-  public void sendError(MessageChannel channel, String message) {
+  public void sendError(ChannelDto channel, String message) {
     send(channel, "[ERROR] " + message);
   }
 
-  private void send(MessageChannel channel, String message) {
+  private void send(ChannelDto channel, String message) {
     String resultMessage;
     if (message.length() > DISCORD_MESSAGE_LENGTH_LIMIT) {
       log.warn("A message is larger than {} symbols. It will be trimmed. "
@@ -42,6 +42,6 @@ public class MessageSenderImpl implements MessageSender {
     } else {
       resultMessage = message;
     }
-    channel.sendMessage(resultMessage).queue();
+    channel.sendMessage(resultMessage);
   }
 }

--- a/src/main/java/com/github/shaart/team/f/discord/bot/dto/AuthorDto.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/dto/AuthorDto.java
@@ -1,0 +1,28 @@
+package com.github.shaart.team.f.discord.bot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.dv8tion.jda.api.entities.User;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorDto {
+
+  private boolean isBot;
+
+  /**
+   * Creates a DTO from library's DTO.
+   *
+   * @param realAuthor library's DTO
+   * @return internal DTO
+   */
+  public static AuthorDto of(User realAuthor) {
+    return AuthorDto.builder()
+        .isBot(realAuthor.isBot())
+        .build();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/dto/ChannelDto.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/dto/ChannelDto.java
@@ -1,0 +1,20 @@
+package com.github.shaart.team.f.discord.bot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChannelDto {
+
+  private MessageChannel realChannel;
+
+  public void sendMessage(String resultMessage) {
+    realChannel.sendMessage(resultMessage).queue();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/dto/EventDto.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/dto/EventDto.java
@@ -1,0 +1,24 @@
+package com.github.shaart.team.f.discord.bot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventDto {
+
+  private MessageReceivedEvent realEvent;
+
+  private ChannelDto channel;
+  private AuthorDto author;
+  private MessageDto message;
+
+  public String getContent() {
+    return message.getContent();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/dto/MessageDto.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/dto/MessageDto.java
@@ -1,0 +1,30 @@
+package com.github.shaart.team.f.discord.bot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.dv8tion.jda.api.entities.Message;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+
+  private String authorName;
+  private String content;
+
+  /**
+   * Creates a DTO from library's DTO.
+   *
+   * @param realMessage library's DTO
+   * @return internal DTO
+   */
+  public static MessageDto of(Message realMessage) {
+    return MessageDto.builder()
+        .authorName(realMessage.getAuthor().getName())
+        .content(realMessage.getContentRaw())
+        .build();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/DtoMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/DtoMapper.java
@@ -1,0 +1,18 @@
+package com.github.shaart.team.f.discord.bot.mapper;
+
+/**
+ * Mapper interface for DTOs.
+ *
+ * @param <S> source
+ * @param <T> target
+ */
+public interface DtoMapper<S, T> {
+
+  /**
+   * Convertes an event to internal event DTO.
+   *
+   * @param receivedEvent event of library type
+   * @return event of app's type
+   */
+  T toInternalDto(S receivedEvent);
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/AuthorMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/AuthorMapper.java
@@ -1,0 +1,15 @@
+package com.github.shaart.team.f.discord.bot.mapper.impl;
+
+import com.github.shaart.team.f.discord.bot.dto.AuthorDto;
+import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
+import net.dv8tion.jda.api.entities.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorMapper implements DtoMapper<User, AuthorDto> {
+
+  @Override
+  public AuthorDto toInternalDto(User author) {
+    return AuthorDto.of(author);
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/ChannelMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/ChannelMapper.java
@@ -1,11 +1,8 @@
 package com.github.shaart.team.f.discord.bot.mapper.impl;
 
 import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
-import com.github.shaart.team.f.discord.bot.dto.EventDto;
 import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
-import net.dv8tion.jda.api.entities.Invite.Channel;
 import net.dv8tion.jda.api.entities.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/ChannelMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/ChannelMapper.java
@@ -1,0 +1,20 @@
+package com.github.shaart.team.f.discord.bot.mapper.impl;
+
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
+import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
+import net.dv8tion.jda.api.entities.Invite.Channel;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChannelMapper implements DtoMapper<MessageChannel, ChannelDto> {
+
+  @Override
+  public ChannelDto toInternalDto(MessageChannel channel) {
+    return ChannelDto.builder()
+        .realChannel(channel)
+        .build();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/EventMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/EventMapper.java
@@ -1,0 +1,44 @@
+package com.github.shaart.team.f.discord.bot.mapper.impl;
+
+import com.github.shaart.team.f.discord.bot.dto.AuthorDto;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
+import com.github.shaart.team.f.discord.bot.dto.MessageDto;
+import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Setter(onMethod = @__(@Autowired))
+public class EventMapper implements DtoMapper<MessageReceivedEvent, EventDto> {
+
+  private ChannelMapper channelMapper;
+  private AuthorMapper authorMapper;
+  private MessageMapper messageMapper;
+
+  @Override
+  public EventDto toInternalDto(MessageReceivedEvent receivedEvent) {
+    final MessageChannel channel = receivedEvent.getChannel();
+    final ChannelDto channelDto = channelMapper.toInternalDto(channel);
+
+    final Message message = receivedEvent.getMessage();
+    final MessageDto messageDto = messageMapper.toInternalDto(message);
+
+    final User author = message.getAuthor();
+    final AuthorDto authorDto = authorMapper.toInternalDto(author);
+
+    return EventDto.builder()
+        .channel(channelDto)
+        .author(authorDto)
+        .message(messageDto)
+        .realEvent(receivedEvent)
+        .build();
+  }
+}

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/EventMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/EventMapper.java
@@ -5,8 +5,6 @@ import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import com.github.shaart.team.f.discord.bot.dto.EventDto;
 import com.github.shaart.team.f.discord.bot.dto.MessageDto;
 import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;

--- a/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/MessageMapper.java
+++ b/src/main/java/com/github/shaart/team/f/discord/bot/mapper/impl/MessageMapper.java
@@ -1,0 +1,15 @@
+package com.github.shaart.team.f.discord.bot.mapper.impl;
+
+import com.github.shaart.team.f.discord.bot.dto.MessageDto;
+import com.github.shaart.team.f.discord.bot.mapper.DtoMapper;
+import net.dv8tion.jda.api.entities.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageMapper implements DtoMapper<Message, MessageDto> {
+
+  @Override
+  public MessageDto toInternalDto(Message message) {
+    return MessageDto.of(message);
+  }
+}

--- a/src/test/java/com/github/shaart/team/f/discord/bot/AbstractIntegrationTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/AbstractIntegrationTest.java
@@ -3,6 +3,10 @@ package com.github.shaart.team.f.discord.bot;
 import static org.mockito.Mockito.when;
 
 import com.github.shaart.team.f.discord.bot.component.MessageSender;
+import com.github.shaart.team.f.discord.bot.dto.AuthorDto;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
+import com.github.shaart.team.f.discord.bot.dto.EventDto;
+import com.github.shaart.team.f.discord.bot.dto.MessageDto;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
@@ -27,7 +31,19 @@ public abstract class AbstractIntegrationTest {
   protected JDA jda;
 
   @Mock
-  protected MessageReceivedEvent messageReceivedEvent;
+  protected MessageReceivedEvent realMessageReceivedEvent;
+
+  @Mock
+  protected EventDto messageReceivedEvent;
+
+  @Mock
+  protected ChannelDto channelDto;
+
+  @Mock
+  protected AuthorDto authorDto;
+
+  @Mock
+  protected MessageDto messageDto;
 
   @Mock
   protected User testUser;
@@ -38,14 +54,24 @@ public abstract class AbstractIntegrationTest {
   @Mock
   protected Message message;
 
+  /**
+   * Global init method.
+   */
   @BeforeEach
   public void init() {
-    when(messageReceivedEvent.getChannel())
+    when(realMessageReceivedEvent.getChannel())
         .thenReturn(messageChannel);
-    when(messageReceivedEvent.getMessage())
+    when(realMessageReceivedEvent.getMessage())
         .thenReturn(message);
-    when(messageReceivedEvent.getAuthor())
+    when(realMessageReceivedEvent.getAuthor())
         .thenAnswer(invocation -> message.getAuthor());
+
+    when(messageReceivedEvent.getChannel())
+        .thenReturn(channelDto);
+    when(messageReceivedEvent.getAuthor())
+        .thenReturn(authorDto);
+    when(messageReceivedEvent.getMessage())
+        .thenReturn(messageDto);
 
     when(testUser.isBot())
         .thenReturn(Boolean.FALSE);

--- a/src/test/java/com/github/shaart/team/f/discord/bot/command/impl/PingCommandIntegrationTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/command/impl/PingCommandIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.github.shaart.team.f.discord.bot.AbstractIntegrationTest;
-import net.dv8tion.jda.api.entities.MessageChannel;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +24,6 @@ class PingCommandIntegrationTest extends AbstractIntegrationTest {
     pingCommand.run(messageReceivedEvent);
 
     verify(messageSender, times(ONCE))
-        .sendMessage(any(MessageChannel.class), eq("Pong!"));
+        .sendMessage(any(ChannelDto.class), eq("Pong!"));
   }
 }

--- a/src/test/java/com/github/shaart/team/f/discord/bot/component/impl/MessageSenderImplTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/component/impl/MessageSenderImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,15 +19,13 @@ class MessageSenderImplTest {
 
   public static final String ERROR_PREFIX = "[ERROR] ";
   private MessageSenderImpl sender;
-  private MessageChannel channel;
-  private MessageAction messageAction;
+  private ChannelDto channel;
 
   @BeforeEach
   void setUp() {
     sender = new MessageSenderImpl();
 
-    channel = mock(MessageChannel.class);
-    messageAction = mock(MessageAction.class);
+    channel = mock(ChannelDto.class);
   }
 
   @Test
@@ -34,18 +33,13 @@ class MessageSenderImplTest {
     final String message = "A message";
     final String expectedResultMessage = ERROR_PREFIX + message;
 
-    when(channel.sendMessage(anyString()))
-        .thenReturn(messageAction);
     doNothing()
-        .when(messageAction).queue();
+        .when(channel).sendMessage(anyString());
 
     sender.sendError(channel, message);
 
-    //noinspection ResultOfMethodCallIgnored
     verify(channel, times(1))
         .sendMessage(eq(expectedResultMessage));
-    verify(messageAction, times(1))
-        .queue();
   }
 
   @Test
@@ -54,18 +48,13 @@ class MessageSenderImplTest {
     final String expectedResultMessage =
         ERROR_PREFIX + "Send message called but message wasn't produced. Please check the logs.";
 
-    when(channel.sendMessage(anyString()))
-        .thenReturn(messageAction);
     doNothing()
-        .when(messageAction).queue();
+        .when(channel).sendMessage(anyString());
 
     sender.sendMessage(channel, null);
 
-    //noinspection ResultOfMethodCallIgnored
     verify(channel, times(1))
         .sendMessage(eq(expectedResultMessage));
-    verify(messageAction, times(1))
-        .queue();
   }
 
   @Test
@@ -80,18 +69,13 @@ class MessageSenderImplTest {
     final String trimmedWithoutPostfix = testMessage.substring(0, 2000 - postfix.length());
     final String expectedResultMessage = trimmedWithoutPostfix + postfix;
 
-    when(channel.sendMessage(anyString()))
-        .thenReturn(messageAction);
     doNothing()
-        .when(messageAction).queue();
+        .when(channel).sendMessage(anyString());
 
     sender.sendMessage(channel, testMessage);
 
-    //noinspection ResultOfMethodCallIgnored
     verify(channel, times(1))
         .sendMessage(eq(expectedResultMessage));
-    verify(messageAction, times(1))
-        .queue();
   }
 
   @Test
@@ -100,17 +84,12 @@ class MessageSenderImplTest {
     final String message = "A message";
     final String expectedResultMessage = ERROR_PREFIX + message;
 
-    when(channel.sendMessage(anyString()))
-        .thenReturn(messageAction);
     doNothing()
-        .when(messageAction).queue();
+        .when(channel).sendMessage(anyString());
 
     sender.sendError(channel, message);
 
-    //noinspection ResultOfMethodCallIgnored
     verify(channel, times(1))
         .sendMessage(eq(expectedResultMessage));
-    verify(messageAction, times(1))
-        .queue();
   }
 }

--- a/src/test/java/com/github/shaart/team/f/discord/bot/listener/TeamFDiscordBotListenerIntegrationTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/listener/TeamFDiscordBotListenerIntegrationTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.shaart.team.f.discord.bot.AbstractIntegrationTest;
 import com.github.shaart.team.f.discord.bot.command.BotCommand;
-import net.dv8tion.jda.api.entities.MessageChannel;
+import com.github.shaart.team.f.discord.bot.dto.ChannelDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,10 +35,10 @@ class TeamFDiscordBotListenerIntegrationTest extends AbstractIntegrationTest {
     when(message.getContentRaw())
         .thenReturn("!ping");
 
-    listener.onMessageReceived(messageReceivedEvent);
+    listener.onMessageReceived(realMessageReceivedEvent);
 
     verify(messageSender, only())
-        .sendMessage(any(MessageChannel.class), eq("Pong!"));
+        .sendMessage(any(ChannelDto.class), eq("Pong!"));
   }
 
   @Test
@@ -49,10 +49,10 @@ class TeamFDiscordBotListenerIntegrationTest extends AbstractIntegrationTest {
     when(message.getContentRaw())
         .thenReturn("!ping ab 12");
 
-    listener.onMessageReceived(messageReceivedEvent);
+    listener.onMessageReceived(realMessageReceivedEvent);
 
     verify(messageSender, only())
-        .sendMessage(any(MessageChannel.class), eq("Pong!"));
+        .sendMessage(any(ChannelDto.class), eq("Pong!"));
   }
 
   @Test
@@ -63,10 +63,10 @@ class TeamFDiscordBotListenerIntegrationTest extends AbstractIntegrationTest {
     when(message.getContentRaw())
         .thenReturn("!help");
 
-    listener.onMessageReceived(messageReceivedEvent);
+    listener.onMessageReceived(realMessageReceivedEvent);
 
     verify(messageSender, only())
-        .sendMessage(any(MessageChannel.class), contains("help - Commands help"));
+        .sendMessage(any(ChannelDto.class), contains("help - Commands help"));
   }
 
   @Test
@@ -77,12 +77,12 @@ class TeamFDiscordBotListenerIntegrationTest extends AbstractIntegrationTest {
     when(message.getContentRaw())
         .thenReturn("!help random");
 
-    listener.onMessageReceived(messageReceivedEvent);
+    listener.onMessageReceived(realMessageReceivedEvent);
 
     final BotCommand commandRandom = commands.get("random");
 
     verify(messageSender, only())
-        .sendMessage(any(MessageChannel.class), contains(commandRandom.getUsage()));
+        .sendMessage(any(ChannelDto.class), contains(commandRandom.getUsage()));
   }
 
   @Test
@@ -93,9 +93,9 @@ class TeamFDiscordBotListenerIntegrationTest extends AbstractIntegrationTest {
     when(message.getContentRaw())
         .thenReturn("!random 1 5");
 
-    listener.onMessageReceived(messageReceivedEvent);
+    listener.onMessageReceived(realMessageReceivedEvent);
 
     verify(messageSender, only())
-        .sendMessage(any(MessageChannel.class), matches(MONOFORMATTED_ONE_DIGIT_FROM_ONE_TO_FIVE));
+        .sendMessage(any(ChannelDto.class), matches(MONOFORMATTED_ONE_DIGIT_FROM_ONE_TO_FIVE));
   }
 }

--- a/src/test/java/com/github/shaart/team/f/discord/bot/service/impl/CommandServiceImplTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/service/impl/CommandServiceImplTest.java
@@ -283,9 +283,11 @@ class CommandServiceImplTest {
       final String commandAlias = prefix + i;
 
       final BotCommand command = mock(BotCommand.class);
+      final String toStringCommand = String.format("Command with alias = '%s' and hash = %d",
+          commandAlias, command.hashCode());
       lenient()
           .when(command.toString())
-          .thenReturn("Command with alias = '" + commandAlias + "' and hash = " + command.hashCode());
+          .thenReturn(toStringCommand);
 
       commands.put(commandAlias, command);
       if (startIndex <= i && i <= endIndex) {

--- a/src/test/java/com/github/shaart/team/f/discord/bot/util/BotStringUtilsTest.java
+++ b/src/test/java/com/github/shaart/team/f/discord/bot/util/BotStringUtilsTest.java
@@ -1,6 +1,7 @@
 package com.github.shaart.team.f.discord.bot.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
To be safe from library's deprecation - library's models wrapped into new internal app's dtos. Tests refactored.